### PR TITLE
Use BrowserRouter instead of HashRouter and fix issue with login

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { HashRouter as Router } from 'react-router-dom'
+import { BrowserRouter as Router } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import * as Sentry from '@sentry/browser'
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/1176362909114831/1178393632609434

I was able to reproduce a similar situation like the one described in the asana issue above,
but without having the session timeout modal box. Instead, I was getting a login failure with a "Session expired" pink message, and it was looping, i.e. subsequent login attempts were failing, too, until I noticed that when I remove the hash from URL in the address bar it does let me login successfully.

I found that the hash in URL comes from HashRouter which is part of React. After replacing HashRouter with BrowserRouter I cannot reproduce the problem. I understand that the only advantage of HashRouter over BrowserRouter is that the former supports old (more than 2 years, I think) browsers, which I assume is something we don't have to do.