### PR TITLE
Fix UI: after session expired once the UI was stuck on "Session expired. Sign in"

### DIFF
--- a/client/src/components/OnboardingRoute.js
+++ b/client/src/components/OnboardingRoute.js
@@ -16,8 +16,6 @@ const OnboardingRoute = ({
   user,
   ...rest
 }) => {
-  setSessionExpired(false)
-
   useEffect(rest.fetchUser, [])
 
   if (rest.sessionExpired && !isLoading) {

--- a/client/src/components/PrivateRoute.js
+++ b/client/src/components/PrivateRoute.js
@@ -24,8 +24,6 @@ const PrivateRoute = ({
 }) => {
   const [expandSidebar, setExpandSidebar] = useState(false)
 
-  setSessionExpired(false)
-
   useEffect(rest.fetchUser, [])
 
   useEffect(

--- a/client/src/utils/agent.js
+++ b/client/src/utils/agent.js
@@ -6,10 +6,9 @@ import { setSessionExpired } from '@/actions/session'
 const agent = request
   .agent()
   .withCredentials(true)
-  .on('error', error => {
-    if (error.status === 401) {
-      store.dispatch(setSessionExpired(true))
-    }
+  .ok(res => {
+    store.dispatch(setSessionExpired(res.status === 401));
+    return res.status < 400;
   })
 
 export default agent


### PR DESCRIPTION
Fix bug in the UI where session expired flag once set was never reset again.

The calls to `setSessionExpired(false)`  in Private and `OnBording` `Routes` did not have any effect. These pure functions return actions as objects that should to be `dispatch`ed to redux.

Previously the expired flag was set in the `on('error', ...)` callback that is called only when response has an error code. Now we check for 401 in the `ok` callback that is always called, regardless of whether the response was an error or not, so the expired flag is reset after successful login.