### PR TITLE
Fixes to make it possible to deploy app in non-production mode on Heroku

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -84,6 +84,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production webpack --loglevel notice",
+    "buildtest": "NODE_ENV=test webpack --loglevel notice",
     "lint": "eslint '**/*.js' && npm run prettier:check",
     "prettier": "prettier --write \"src/**/*.js\" \"test/**/*.js\"",
     "prettier:check": "prettier -c \"src/**/*.js\" \"test/**/*.js\"",

--- a/client/src/constants/index.js
+++ b/client/src/constants/index.js
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV === 'production') {
     apiUrl = process.env.INVESTOR_API_URL
   }
 } else {
-  apiUrl = 'http://localhost:5000'
+  apiUrl = process.env.TEAM_API_URL || process.env.INVESTOR_API_URL || 'http://localhost:5000';
 }
 
 export { apiUrl, pageTitle }

--- a/client/src/lib/eth.js
+++ b/client/src/lib/eth.js
@@ -1,11 +1,5 @@
 function getEthNetwork() {
-  let network;
-  if (process.env.NODE_ENV === 'production') {
-    network = 'mainnet';
-  } else {
-    network = 'ropsten'
-  }
-
+  let network = process.env.ETH_NETWORK || (process.env.NODE_ENV === 'production' ? 'mainnet' : 'ropsten');
   return network;
 }
 

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -48,10 +48,10 @@ if (app.get('env') === 'production') {
   app.set('trust proxy', 1) // trust first proxy
   sessionConfig.cookie.secure = true // serve secure cookies in production
 } else {
-  // CORS configuration for local development
+  // CORS configuration for local development and test deployments in the cloud (CI)
   app.use(
     cors({
-      origin: 'http://localhost:3000',
+      origin: process.env.DEPLOYMENT_URL || 'http://localhost:3000',
       credentials: true,
       exposedHeaders: ['X-Authenticated-Email']
     })
@@ -64,7 +64,7 @@ if (process.env.HEROKU) {
   const corsWhitelist = [
     'https://tt-ecosystem-portal-web.herokuapp.com',
     'https://portal.trusttoken.com',
-  ];
+  ].concat(process.env.CLIENT_URL ? [process.env.CLIENT_URL] : []);
 
   app.use(
     cors({


### PR DESCRIPTION
Fixed configuration handling to allow for non-production deployment on Heroku, needed for CI.

- add script `buildtest` to client's yarn config to be able to build webpack with `NODE_ENV=test`,
- fix hardcoded `apiUrl = 'http://localhost:5000'` if NODE_ENV is different than `production`. Now it will try to use TEAM_API_URL or INVESTOR_API_URL and `'http://localhost:5000'` only if TEAM_API_URL and INVESTOR_API_URL not set,
- add ETH_NETWORK to client's config for better control over which network is used. If ETH_NETWORK is not set it will use the old rule: mainnet for production, otherwise ropsten,
- add DEPLOYMENT_URL to server's configuration so in non-production mode CORS origin doesn't have to be `'http://localhost:3000'`,
- CLIENT_URL will be added to CORS whitelist on the server, if set.
