### PR TITLE
Fix unlocking progress bar and table

### DIFF
--- a/client/src/components/VestingBars.js
+++ b/client/src/components/VestingBars.js
@@ -6,6 +6,8 @@ import BigNumber from 'bignumber.js'
 
 import { DataContext } from '@/providers/data';
 
+import { vestingSchedule } from '@trusttoken/token-transfer-server/src/lib/vesting'
+
 const DateAndDayLabel = styled.div`
   margin-top: 4px;
   margin-left: -50%;
@@ -56,8 +58,9 @@ const VestingBars = ({ user }) => {
   const lastEndDate = moment(Math.max(...grants.map(g => g.end)))
   const totalDuration = lastEndDate - firstStartDate
 
+  const maxMarkers = 8;
+
   const generateMarkers = () => {
-    const maxMarkers = 8;
 
     const monthMarkers = generateMonthMarkers(maxMarkers);
     const amountMarkers = generateAmountMarkers(maxMarkers);
@@ -141,12 +144,15 @@ const VestingBars = ({ user }) => {
         {grants.map(grant => {
           // Calculate the percentage of the grant that is complete with a
           // upper bound of 100
-          const complete = data.config.isLocked
-            ? 0
-            : Math.min(
-                ((now - grant.start) / (grant.end - grant.start)) * 100,
-                100
-              )
+
+          let i = 0;
+          vestingSchedule(user, grant).forEach((vest, index) => {
+              if (vest.vested) {
+                  i = index;
+              }
+          });
+
+          const complete = data.config.isLocked ? 0 : Math.min((100.0 / maxMarkers) * i, 100)
           // Calculate the width of the grant relative to the width of the
           // total component
           const width = ((grant.end - grant.start) / totalDuration) * 100

--- a/client/src/components/VestingHistory.js
+++ b/client/src/components/VestingHistory.js
@@ -8,11 +8,19 @@ import { DataContext } from '@/providers/data'
 const VestingHistory = props => {
   const data = useContext(DataContext)
 
+  // Once we know the actual start date we will update it in the database
+  // (start date cannot be null in the database, so we have to enter a 'fake' one initially)
+  // and start showing it.
+  // For now we show only days from an unspecified start date.
+  const showStartDate = false;
+
   const schedule = {}
   data.grants.forEach(grant => {
+    let accumulated = 0;
     vestingSchedule(props.user, grant).forEach(vest => {
+      accumulated += vest.amount;
       const dateKey = vest.date.format()
-      schedule[dateKey] = vest.day;
+      schedule[dateKey] = {accumulated: accumulated, day: vest.day, date: dateKey}
     })
   })
 
@@ -29,14 +37,18 @@ const VestingHistory = props => {
           ></div>
         </td>
         <td className="text-nowrap" width="130px">
-          {Number(schedule[date]).toLocaleString()} TRU
+          {Number(schedule[date].accumulated).toLocaleString()} TRU
         </td>
         <td className="d-none d-sm-block">
           <span className="text-muted">
             {momentDate < moment.now() ? 'Unlocked' : 'Locked'}
           </span>
         </td>
-        <td className="text-right">Day {schedule[date]}</td>
+        {
+         showStartDate
+         ? <td className="text-right"> {schedule[date].date.slice(0, -10)}</td>
+         : <td className="text-right">Day {schedule[date].day}</td>
+        }
       </tr>
     )
   }


### PR DESCRIPTION
Asana task: [Design change for unlocking progress](https://app.asana.com/0/1178660350796489/1181157928879937)

**Unlocking Progress** was fixed to show unlocked TRU only (discrete, full vests, rather than parts).

**My Unlocking Schedule** was fixed to show calculated unlocked amount of TRU, rather than days.

Currently unlocking progress is showing days from an unspecified start, rather than concrete dates.

![Current view: days instead of dates](https://i.ibb.co/3B2v6nn/Screenshot-from-2020-07-07-00-53-13.png)

When we decide on the start date this behavior can be changed by setting `showStartDate` variable in the code to `true`:

![In the future: concrete dates](https://i.ibb.co/d4m66xg/Screenshot-from-2020-07-07-00-55-09.png)
