### PR TITLE
Fix issue when some users can see blank page, reported by Jack

### DIFF
--- a/client/src/contracts/EthService.js
+++ b/client/src/contracts/EthService.js
@@ -73,7 +73,12 @@ function getEthNetwork() {
 }
 
 function isConnectedToMetaMask() {
-  return typeof window.ethereum !== "undefined" && window.ethereum.selectedAddress;
+  try {
+    return typeof window.ethereum !== "undefined" && window.ethereum.selectedAddress;
+  } catch (error) {
+    console.log("isConnectedToMetaMask: " + JSON.stringify(error));
+    return false;
+  }
 }
 
 function getTrustTokenContract() {


### PR DESCRIPTION
Fix issue occurring to some users where they see a blank landing page.

Method `isConnectedToMetMask` uses a deprecated MetaMask API `ethereum.selectedAddress` that can throw an exception `Invalid JSON RPC response: undefined` for some users and works OK for others. MetaMask API gives an alternative to the deprecated API but using it would require significant refactoring of the  `isConnectedToMetMask` client code, as the new method is asynchronous, unlike `ethereum.selectedAddress`. Therefore, for now I decided to just catch the exception that can be thrown when `ethereum.selectedAddress` is invoked, and return `false` from  `isConnectedToMetMask`  in this case.