### PR TITLE
Calculate purchased amount as a sum of lockedBalance and unlockedBalance

### DIFF
--- a/client/src/components/VestingBars.js
+++ b/client/src/components/VestingBars.js
@@ -40,8 +40,6 @@ const Ticker = styled.div`
 `;
 
 const VestingBars = ({grants}) => {
-  //const data = useContext(DataContext)
-
   const [displayPopover, setDisplayPopover] = useState({})
 
   if (!grants || grants.length === 0) {

--- a/client/src/contracts/EthService.js
+++ b/client/src/contracts/EthService.js
@@ -24,6 +24,7 @@ const EthService = {
   disableTrueReward,
   depositStakedToken,
   getTrustTokenBalance,
+  getTrustTokenSumLockedAndUnlocked,
   getTrustTokenLockStart,
   getTrustTokenEpochsPassed,
   getTrustTokenFinalEpoch,
@@ -113,12 +114,22 @@ async function registeredDistributions(address) {
   }
 }
 
+async function getTrustTokenSumLockedAndUnlocked(address) {
+  console.log("getTrustTokenSumLockedAndUnlocked(" + address + ")");
+  const TrustTokenContract = getTrustTokenContract();
+  const lockedBalance = await TrustTokenContract.lockedBalance(address);
+  const unlockedBalance = await TrustTokenContract.unlockedBalance(address);
+  const sum = (lockedBalance + unlockedBalance) / 100000000;
+  console.log(`Sum of locked and unlocked TRU of address ${address} is ${sum}`);
+  return sum;
+}
+
 async function getTrustTokenBalance(address) {
   console.log("getTrustTokenBalance(" + address + ")");
   const TrustTokenContract = getTrustTokenContract();
   const trustTokenBalance = await TrustTokenContract.balanceOf(address);
   const balance = trustTokenBalance / 100000000;
-  console.log(`TRU balance of address ${address} on is ${balance}`);
+  console.log(`TRU balance of address ${address} is ${balance}`);
   return balance;
 }
 
@@ -270,7 +281,7 @@ async function init(type) {
 
 async function loadGrant() {
   const account = await getActiveAccount();
-  const amount = await getTrustTokenBalance(account);
+  const amount = await getTrustTokenSumLockedAndUnlocked(account);
   const start = await getTrustTokenLockStart();
   const end = await getTrustTokenFinalEpoch();
   const cliff = moment(start).add(120, 'days');


### PR DESCRIPTION
This PR fixes numbers shown on the dashboard: purchased amount of TRU is now calculated as sum of `lockedBalance` and `unlockedBalance` rather than `balanceOf`, which was only correct before the first unlock time.

PR deployed to staging (on Ropsten) here:

https://peter-tt-ecosystem-portal-web.herokuapp.com/dashboard